### PR TITLE
feat: add cross-reference links

### DIFF
--- a/app/privacy-policy/page.mdx
+++ b/app/privacy-policy/page.mdx
@@ -54,7 +54,7 @@ We will never sell or rent your personal data to third parties. We may combine y
 
 We may have to share your personal data with the parties set out below for the purposes set out in Section 4 above:
 
-- **Legal advisors** — If we believe that disclosure is reasonably necessary: (1) to comply with any applicable law, regulation, legal process or governmental request; (2) to establish, exercise or defend our legal rights; (3) to enforce or comply with our Terms and Conditions; or (4) to protect us, users of our Website or the public from harm, fraud, or potentially prohibited or illegal activities.
+- **Legal advisors** — If we believe that disclosure is reasonably necessary: (1) to comply with any applicable law, regulation, legal process or governmental request; (2) to establish, exercise or defend our legal rights; (3) to enforce or comply with our [Terms and Conditions](/terms-of-use/); or (4) to protect us, users of our Website or the public from harm, fraud, or potentially prohibited or illegal activities.
 - **Service Providers** — The Company may provide your personal information to other companies who help us provide, maintain, and improve the Website.
 - **Professional advisers** — In order to comply with our legal obligations, we may need to share information with professional advisers who provide consultancy, banking, compliance, insurance, or accounting services.
 - **Third parties** — We may choose to sell, transfer, or merge parts of our business or our assets to third parties. Alternatively, we may acquire other businesses or merge with them. If a change happens to our business, then the new owners may use your personal data in the same way as set out in this privacy policy.

--- a/app/terms-of-use/page.mdx
+++ b/app/terms-of-use/page.mdx
@@ -14,7 +14,7 @@ The Website is not intended for children under the age of majority in the countr
 
 ## 3. Privacy Policy
 
-We are committed to protecting your personal information and helping you understand exactly how your personal information is being used. You should carefully read our Privacy Policy, as it provides details on how your personal information is collected, stored, protected, and used.
+We are committed to protecting your personal information and helping you understand exactly how your personal information is being used. You should carefully read our [Privacy Policy](/privacy-policy/), as it provides details on how your personal information is collected, stored, protected, and used.
 
 ## 4. No Reliance on Information
 


### PR DESCRIPTION
Adds cross-reference links on /terms-of-use and /privacy-policy pages, when mentioning the other document.