### PR TITLE
feat: add Netlify redirects configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "https://geodework.netlify.app/*"
+  to = "https://geodework.com/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
- add Netlify redirects configuration

## Context
`https://geodework.netlify.app` domain is indexed in google search at the moment, which potentially exacerbates the SEO for duplicate contents as well as UX for those who bookmarks it while it's not decided we will keep using Netlify.