### PR TITLE
refactor: Add metadata generation function as a single source of truth

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,30 +5,9 @@ import GeodeIcon from "@/components/GeodeIcon"
 import About from "./content.mdx"
 
 import HeroBackground from "@/components/HeroBackground"
-import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/constants"
-import type { Metadata } from "next/types"
+import { generateMetadata } from "@/lib/metadata"
 
-const title = "About " + SITE_NAME
-const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
-
-export const metadata: Metadata = {
-  title,
-  description,
-  openGraph: {
-    title,
-    description,
-    type: "website",
-    url: SITE_URL,
-    images: [{ url: ogImage }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-    images: [ogImage],
-  },
-}
+export const metadata = generateMetadata('About')
 
 const overrideComponents: MDXComponents = {
   h1: ({ children }) => (

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -25,6 +25,7 @@ export function generateStaticParams() {
   return posts.map((post) => ({ slug: post.slug }))
 }
 
+// TODO: Integrate generateMetadata in @lib/metadata.ts
 export async function generateMetadata({
   params,
 }: BlogPostPageProps): Promise<Metadata> {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -10,28 +10,9 @@ import { formatDate } from "@/lib/datetime"
 
 import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from "@/lib/constants"
 import { generateClipPath } from "@/styles/clipPaths"
+import { generateMetadata } from "@/lib/metadata"
 
-const title = SITE_NAME + " Blog"
-const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
-
-export const metadata: Metadata = {
-  title,
-  description,
-  openGraph: {
-    title,
-    description,
-    type: "website",
-    url: SITE_URL,
-    images: [{ url: ogImage }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-    images: [ogImage],
-  },
-}
+export const metadata = generateMetadata(SITE_NAME + " Blog")
 
 export default async function Blog() {
   const blogPosts = getBlogPosts()

--- a/app/donations/page.tsx
+++ b/app/donations/page.tsx
@@ -2,10 +2,9 @@ import { QRCode } from "@/components/ui/qr-code"
 import { SITE_NAME, ETHEREUM_ADDRESS, ETHEREUM_ENS, BITCOIN_ADDRESS, BUY_ME_A_COFFEE_URL } from "@/lib/constants"
 import { CopyButton } from "@/components/ui/copy-button"
 import BitcoinLogo from "@/components/svgs/bitcoin.svg"
-import BuyMeACoffeeLogo from "@/components/svgs/buymeacoffee.svg"
 import Link from "@/components/ui/link"
 import { shortenAddress } from "@/lib/web3"
-
+import { generateMetadata } from "@/lib/metadata"
 const alternativeOptions: {
   name: string,
   url: string,
@@ -15,6 +14,8 @@ const alternativeOptions: {
     url: BUY_ME_A_COFFEE_URL,
   }
 ]
+
+export const metadata = generateMetadata("Donations")
 
 export default function Donations() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,28 +13,9 @@ import Heart from "@/components/svgs/heart.svg"
 
 import "@/styles/globals.css"
 import Matomo from "@/components/Matomo"
+import { generateMetadata } from "@/lib/metadata"
 
-const title = SITE_NAME
-const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
-
-export const metadata: Metadata = {
-  title,
-  description,
-  openGraph: {
-    title,
-    description,
-    type: "website",
-    url: SITE_URL,
-    images: [{ url: ogImage }],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title,
-    description,
-    images: [ogImage],
-  },
-}
+export const metadata = generateMetadata()
 
 export default function RootLayout({
   children,

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,28 @@
+import type { Metadata } from "next/types"
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "./constants"
+
+function generateMetadata(title?: string, description?: string): Metadata{
+  const fullTitle = title ? title + " | " + SITE_NAME : SITE_NAME
+  const fullDescription = description || SITE_DESCRIPTION
+  const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(fullTitle)}`
+
+  return {
+    title: fullTitle,
+    description: fullDescription,
+    openGraph: {
+      title: fullTitle,
+      description: fullDescription,
+      type: "website",
+      url: SITE_URL,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: fullTitle,
+      description: fullDescription,
+      images: [ogImage],
+    },
+  }
+}
+
+export { generateMetadata }


### PR DESCRIPTION
- Add metadata generation function as a single source of truth to reduce duplicate codes