### PR TITLE
Fix metadata URLs for pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -10,16 +10,17 @@ import type { Metadata } from "next/types"
 
 const title = "About " + SITE_NAME
 const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
+const ogImage = `/og?title=${encodeURIComponent(title)}`
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title,
   description,
   openGraph: {
     title,
     description,
     type: "website",
-    url: SITE_URL,
+    url: "about",
     images: [{ url: ogImage }],
   },
   twitter: {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,16 +13,17 @@ import { generateClipPath } from "@/styles/clipPaths"
 
 const title = SITE_NAME + " Blog"
 const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
+const ogImage = `og?title=${encodeURIComponent(title)}`
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title,
   description,
   openGraph: {
     title,
     description,
     type: "website",
-    url: SITE_URL,
+    url: "blog",
     images: [{ url: ogImage }],
   },
   twitter: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,16 +16,17 @@ import Matomo from "@/components/Matomo"
 
 const title = SITE_NAME
 const description = SITE_DESCRIPTION
-const ogImage = `${SITE_URL}/og?title=${encodeURIComponent(title)}`
+const ogImage = `/og?title=${encodeURIComponent(title)}`
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title,
   description,
   openGraph: {
     title,
     description,
     type: "website",
-    url: SITE_URL,
+    url: "/",
     images: [{ url: ogImage }],
   },
   twitter: {


### PR DESCRIPTION
Update metadata URLs in the About, Blog, and Layout components to ensure proper generation of Open Graph images and metadata base.